### PR TITLE
🐛 fix(countdown-badge): text-white in dark mode as well, fixed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,7 +132,7 @@ const FeaturedBento = ({ className }) => (
   <div className={cn('relative grid size-full grid-cols-2 content-center gap-x-4 gap-y-8 tablet:grid-cols-3 tablet:gap-x-8 laptop:grid-cols-6', className)}>
     {seasonsData.map((season) => (
       <div key={season.key} className="relative col-span-1 row-span-1 flex h-full flex-1 flex-col items-center self-center">
-        <Badge className="z-10 -mb-2 border-none bg-blue-600 text-xs tablet:text-sm">{season.key}</Badge>
+        <Badge className="z-10 -mb-2 border-none bg-blue-600 text-xs text-white tablet:text-sm">{season.key}</Badge>
         <Countdown
           className="relative aspect-auto size-full flex-1"
           {...season}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- Dark mode 에서 BentoBox Countdown 의 Badge text 색이 검은색으로 변하는 문제 수정 (흰색으로 고정)
