### PR TITLE
Develop

### DIFF
--- a/config/navBar.ts
+++ b/config/navBar.ts
@@ -15,21 +15,21 @@ export const navContents: NavItem[] = [
     title: 'Redeem',
     href: '/redeem',
   },
-  {
-    title: 'Karts',
-    href: '/karts',
-    items: [
-      {
-        title: 'Legendary Karts',
-        href: '/karts/legendary',
-        label: 'New',
-      },
-      {
-        title: 'Rare Karts',
-        href: '/karts/rare',
-      },
-    ],
-  },
+  // {
+  //   title: 'Karts',
+  //   href: '/karts',
+  //   items: [
+  //     {
+  //       title: 'Legendary Karts',
+  //       href: '/karts/legendary',
+  //       label: 'New',
+  //     },
+  //     {
+  //       title: 'Rare Karts',
+  //       href: '/karts/rare',
+  //     },
+  //   ],
+  // },
   // {
   //   title: 'Riders',
   //   href: '/riders',

--- a/src/components/Blog/BlogFeatured.tsx
+++ b/src/components/Blog/BlogFeatured.tsx
@@ -24,7 +24,9 @@ export default function BlogFeatured({
         alt="blog-featured-thumbnail"
         width={1920}
         height={1080}
-        wrapperClassName="rounded-lg w-full h-auto"
+        // gridNums={[1, 2, 3]}
+        wrapperClassName="flex items-center justify-center"
+        imageClassName="rounded-lg w-full h-auto"
         isPriority
       />
       <div className="laptop:min-w-md flex flex-col justify-center gap-3 tablet_only:max-w-md">

--- a/src/components/Button/FileButton.tsx
+++ b/src/components/Button/FileButton.tsx
@@ -47,14 +47,15 @@ const FileButton = ({
 
   return (
     <button
-      name="fileDownloadBtn"
+      id="fileDownloadBtn"
+      aria-label="file-download-button"
       onClick={handleDownload}
       className={`${className} ${width}`}
     >
       <h1 className={`uppercase ${titleAlign} ${titleTextColor} ${titleFontSize} ${titleFontWeight}`}>{title}</h1>
       {isDownloadDecorationExist && (
         <div className="flex items-center gap-3">
-          <h3 className="text-center text-base font-normal text-gray-600">Download</h3>
+          <p className="text-center text-base font-normal text-gray-600">Download</p>
           <Download />
         </div>
       )}

--- a/src/components/Button/ScrollToTopButton.tsx
+++ b/src/components/Button/ScrollToTopButton.tsx
@@ -41,7 +41,8 @@ const ScrollToTopButton = () => {
   return (
     <div className="fixed bottom-6 right-4 z-50 tablet:bottom-12 tablet:right-8">
       <button
-        name="scrollToTopBtn"
+        id="scrollToTopBtn"
+        aria-label="scroll-to-top-button"
         onClick={scrollToTop}
         className={
           `rounded-full bg-zinc-500 p-3 text-white transition duration-200 ease-in-out focus:outline-none dark:bg-zinc-600 tablet:p-4

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -69,7 +69,6 @@ const Countdown = ({
               alt={currentSeason.alt}
               gridNums={[2, 3, 3]}
               isPriority
-              wrapperClassName="tablet:px-4"
             />
           ) : (
             <div className="mt-4">

--- a/src/components/Image/StaticImage.tsx
+++ b/src/components/Image/StaticImage.tsx
@@ -11,6 +11,7 @@ interface StaticImageProps {
   aspectRatio?: string;
   gridNums?: number[];
   isPriority?: boolean;
+  objectFit?: string;
   wrapperClassName?: string;
   imageClassName?: string;
 }
@@ -25,6 +26,7 @@ const StaticImage = ({
   aspectRatio = 'aspect-auto',
   gridNums = [1, 2, 2],
   isPriority = false,
+  objectFit = 'object-cover',
   wrapperClassName,
   imageClassName,
 }: StaticImageProps) => (
@@ -39,7 +41,7 @@ const StaticImage = ({
       height={targetHeight}
       sizes={dynamicViewport(gridNums)}
       priority={isPriority}
-      className={cn('relative', imageClassName)}
+      className={cn(`relative ${objectFit}`, imageClassName)}
     />
   </div>
 );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -33,7 +33,7 @@ const CardTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-  <h3
+  <h1
     ref={ref}
     className={cn(
       'text-2xl font-semibold leading-none tracking-tight',


### PR DESCRIPTION
## 🧑‍💻 PR 내용

### Lighthouse Audit Fix

- Button aria-label (for screen readers)
- Title cascade order fix - shadcn CardTitle
- 404 routes commented out so that they won't be logged into the console
- (Note for BlogFeatured) The thumbnail should stick with StaticImage to prevent CLS & Image size is fine the way it is now as the default gridNums value is set in the StaticImage component itself

<img width="1582" alt="Screenshot 2024-03-24 at 5 49 28 PM" src="https://github.com/gvm1229/krrpinfo/assets/31644837/5fc30f1c-f888-4973-80aa-6472d4c76ce5">

### Misc

- Static image object-fit added (default object-cover)
- BlogFeatured 에서 이미지가 가끔 각지게 되는 문제 해결, 이미지 자체에 size option 적용하고 flexbox 로 상하 정렬 맞춰서 해결