### PR TITLE
🐛 fix(rootpage): countdown props doesn't need to be spread as there's…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,7 +135,7 @@ const FeaturedBento = ({ className }) => (
         <Badge className="z-10 -mb-2 border-none bg-blue-600 text-xs text-white tablet:text-sm">{season.key}</Badge>
         <Countdown
           className="relative aspect-auto size-full flex-1"
-          {...season}
+          seasons={season.seasons}
         />
       </div>
     ))}


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- Countdown 에서 필히 요구하는 props 는 이제 seasons 밖에 안 남았으니 spread operator 더 이상 안 사용해도 됨, 직접 패스해줌으로써 warning 해결