### PR TITLE
🐛 fix(youtubers): channelCard size fix for safari

### DIFF
--- a/src/components/Card/YouTubeChannelCard.tsx
+++ b/src/components/Card/YouTubeChannelCard.tsx
@@ -21,7 +21,7 @@ export default function YouTubeChannelCard({
   channelData: YouTubeChannel
 }) {
   return (
-    <Card className="size-full">
+    <Card>
       <CardContent className="flex items-start gap-4 p-4">
         <Avatar className="size-24">
           <AvatarImage src={channelData.thumbnail.url} alt={channelData.customUrl} />


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- 추천 유튜버 목록 Safari 브라우저에서 각 Card 크기가 overflow 되는 현상 수정

size-full 이 Safari 에서 문제되는 것 같음.. 문제되는 때가 있고 없고 하기 때문에 정확히 언제 어디서 size-full 을 썼을 때 문제가 발생하는지 알아둬야 함.
