### PR TITLE
strict/full → develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ A "where to find what" map. Paths are relative to repo root.
 
 - `config/site.ts`, `config/navBar.ts` — site metadata & nav definition
 - `env.mjs` — typed env validation (`@t3-oss/env-nextjs`)
-- `next.config.js`, `tailwind.config.js`, `postcss.config.js`, `tsconfig.json`, `components.json`
+- `next.config.js`, `tailwind.config.js`, `postcss.config.js`, `tsconfig.json`, `components.json`, `proxy.ts`
 - Path aliases (tsconfig): `@/*` → repo root, `@/components/*` → `src/components/*`
 
 ### Static assets — `public/`

--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,32 @@
+# PR: strict/full branch
+
+## Summary
+
+- `develop` 대비 TypeScript `strict: true` 전환으로 타입 안정성 강화
+- youtubers video metadata의 `keywords` 타입 처리 보강으로 Next.js production build 실패 해소
+- Next.js 16 deprecation 대응으로 `middleware` warning 제거
+
+## Changes
+
+## ♻️ TypeScript strict 전환
+
+- `tsconfig.json` `strict: true` 활성화
+- `app/actions`, `app/posts`, `app/youtubers`, `src/components`, `src/util`, `src/lib` 전반의 null/undefined 타입 처리 정리
+- build 단계 TypeScript 오류를 코드 레벨에서 선제 차단
+
+## 🐛 YouTubers metadata build fix
+
+- `app/youtubers/[channelId]/_[videoId]/page.tsx`에서 `parent.keywords`를 배열로 정규화
+- `snippet.tags` 유무와 관계없이 metadata `keywords`를 안전하게 병합
+- Next.js build type check에서 발생한 spread 오류 해소
+
+## 🐛 Proxy migration
+
+- 루트 `middleware.ts`를 `proxy.ts`로 rename
+- export 함수명을 `proxy`로 변경해 Next.js 16 file convention에 맞춤
+- 기존 matcher와 feature flag 동작은 유지하면서 build warning만 제거
+
+## 🔧 Version / docs
+
+- `package.json` patch version `0.1.9` 반영
+- `docs/logs/20260416-strict-true-migration.md`에 metadata fix와 proxy migration 내역 반영

--- a/app/actions/couponRedeem.ts
+++ b/app/actions/couponRedeem.ts
@@ -64,7 +64,7 @@ export async function handleUserLookup(payload: UserLookUpPayload) {
         body: JSON.stringify(payload),
       },
     );
-    return await response.json() as UserLookUpResponse;
+    return (await response.json()) as UserLookUpResponse;
   } catch (error) {
     // console.error('Error fetching user:', error);
     throw new Error(`Error fetching user: ${error}`);
@@ -125,7 +125,7 @@ export async function handleRedeem(payload: RedeemPayload) {
         body: JSON.stringify(payload),
       },
     );
-    return await response.json() as RedeemResponse;
+    return (await response.json()) as RedeemResponse;
   } catch (error) {
     // console.error('Error fetching coupon:', error);
     throw new Error(`Error fetching coupon: ${error}`);
@@ -133,8 +133,8 @@ export async function handleRedeem(payload: RedeemPayload) {
 }
 
 interface UnifiedResponse {
-  success: boolean
-  message: string
+  success: boolean;
+  message: string;
 }
 
 export async function handleUnified(npaCode: string, coupon: string): Promise<UnifiedResponse> {
@@ -147,7 +147,7 @@ export async function handleUnified(npaCode: string, coupon: string): Promise<Un
     const payload = { npaCode, coupon, region };
     const responseData = await handleUserLookup(payload);
     // console.log('Unified responseData', responseData);
-    if (responseData.result)
+    if (responseData.result && responseData.info)
       try {
         const redeemPayload = {
           coupon,
@@ -159,16 +159,15 @@ export async function handleUnified(npaCode: string, coupon: string): Promise<Un
         };
         const redeemResponseData = await handleRedeem(redeemPayload);
         // console.log('Unified redeemResponseData', redeemResponseData);
-        if (redeemResponseData.result && responseData.info) // 안전을 위해 둘 다
+        if (redeemResponseData.result && responseData.info)
+          // 안전을 위해 둘 다
           return {
             success: true,
             message: `[${responseData.info[0].name}] 에게 [${coupon}] 쿠폰 사용 성공`,
           };
         return {
           success: false,
-          message:
-            reformatMessage(redeemResponseData.message)
-            ?? '이미 사용된 쿠폰 / 잘못된 입력',
+          message: reformatMessage(redeemResponseData.message) ?? '이미 사용된 쿠폰 / 잘못된 입력',
         };
       } catch (error) {
         // console.error('[Unified] Error fetching coupon:', error);
@@ -180,9 +179,7 @@ export async function handleUnified(npaCode: string, coupon: string): Promise<Un
     else
       return {
         success: false,
-        message:
-          reformatMessage(responseData.message)
-          ?? '이미 사용된 쿠폰 / 잘못된 입력',
+        message: reformatMessage(responseData.message) ?? '이미 사용된 쿠폰 / 잘못된 입력',
       };
   } catch (error) {
     // console.error('[Unified] Error fetching user:', error);

--- a/app/actions/handleYTData.ts
+++ b/app/actions/handleYTData.ts
@@ -33,7 +33,7 @@ export async function getAllChannels(): Promise<YouTubeChannel[]> {
   const db = (await mongoClient()).db('youtubers');
 
   try {
-    return db.collection('channels').find().toArray();
+    return db.collection<YouTubeChannel>('channels').find().toArray();
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
     throw new Error(`Failed to retrieve all channels: ${error}`);
@@ -50,7 +50,7 @@ export async function getChannel(channelId: string): Promise<YouTubeChannel | nu
   const db = (await mongoClient()).db('youtubers');
 
   try {
-    return db.collection('channels').findOne({ channelId });
+    return db.collection<YouTubeChannel>('channels').findOne({ channelId });
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
     throw new Error(`Failed to retrieve individual channel: ${error}`);
@@ -96,9 +96,7 @@ export async function editChannel(channelId: string, newChannelData: YouTubeChan
   const db = (await mongoClient()).db('youtubers');
 
   try {
-    await db
-      .collection('channels')
-      .updateOne({ channelId }, { $set: newChannelData });
+    await db.collection('channels').updateOne({ channelId }, { $set: newChannelData });
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
     throw new Error(`Failed to edit channel: ${error}`);
@@ -117,8 +115,7 @@ export async function editChannel(channelId: string, newChannelData: YouTubeChan
 export async function checkIfVideoExists(channelId: string, videoId: string): Promise<boolean> {
   const isExistingChannel = await checkIfChannelExists(channelId);
 
-  if (!isExistingChannel)
-    return false;
+  if (!isExistingChannel) return false;
 
   try {
     const allVideos = await getAllVideos(channelId);
@@ -139,7 +136,8 @@ export async function getAllVideos(channelId: string): Promise<YouTubeVideoItem[
   const db = (await mongoClient()).db('youtubers');
 
   try {
-    const channel: YouTubeChannel = await db.collection('channels').findOne({ channelId });
+    const channel = await db.collection<YouTubeChannel>('channels').findOne({ channelId });
+    if (!channel) throw new Error(`Channel not found: ${channelId}`);
     return channel.allVideos;
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
@@ -147,7 +145,10 @@ export async function getAllVideos(channelId: string): Promise<YouTubeVideoItem[
   }
 }
 
-export async function getVideosByCategory(channelId: string, category: string): Promise<YouTubeVideoItem[]> {
+export async function getVideosByCategory(
+  channelId: string,
+  category: string,
+): Promise<YouTubeVideoItem[]> {
   const allVideos = await getAllVideos(channelId);
   return allVideos.filter((video: YouTubeVideoItem) => video.category === category);
 }
@@ -159,10 +160,13 @@ export async function getVideosByCategory(channelId: string, category: string): 
  * @param {string} videoId - The ID of the YouTube video.
  * @return {Promise<YouTubeVideoItem>} The YouTube video item if found.
  */
-export async function getVideo(channelId: string, videoId: string): Promise<YouTubeVideoItem | null> {
+export async function getVideo(
+  channelId: string,
+  videoId: string,
+): Promise<YouTubeVideoItem | null> {
   try {
     const allVideos = await getAllVideos(channelId);
-    return allVideos.find((video: YouTubeVideoItem) => video.id === videoId);
+    return allVideos.find((video: YouTubeVideoItem) => video.id === videoId) ?? null;
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
     throw new Error(`Failed to retrieve individual video: ${error}`);
@@ -181,8 +185,8 @@ export async function insertOneVideo(channelId: string, videoData: YouTubeVideoI
 
   try {
     await db
-      .collection('channels')
-      .updateOne({ channelId }, { $push: { allVideos: videoData } });
+      .collection<YouTubeChannel>('channels')
+      .updateOne({ channelId }, { $push: { allVideos: videoData } as never });
   } catch (error) {
     // Handle the error, you can log it or throw a custom error
     throw new Error(`Failed to insert video: ${error}`);
@@ -197,7 +201,11 @@ export async function insertOneVideo(channelId: string, videoData: YouTubeVideoI
  * @param {YouTubeVideoItem} newVideoData - The updated video data
  * return nothing as this function just performs an action
  */
-export async function editVideo(channelId: string, videoId: string, newVideoData: YouTubeVideoItem) {
+export async function editVideo(
+  channelId: string,
+  videoId: string,
+  newVideoData: YouTubeVideoItem,
+) {
   const db = (await mongoClient()).db('youtubers');
 
   try {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -110,8 +110,8 @@ export const viewport = {
 
 export const revalidate = 60;
 
-export default async function RootLayout({ children }) {
-  const userAgent: string = (await headers()).get('user-agent');
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const userAgent: string = (await headers()).get('user-agent') ?? '';
   const posts = await getPostsForSearch();
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -204,7 +204,7 @@ const seasonsData = [
   },
 ];
 
-const FeaturedBento = ({ className }) => (
+const FeaturedBento = ({ className }: { className?: string }) => (
   <div
     className={cn(
       'relative grid size-full grid-cols-2 content-center gap-x-4 gap-y-8 tablet:grid-cols-3 tablet:gap-x-8 laptop:grid-cols-6',
@@ -308,7 +308,7 @@ async function Posts({ className }: { className?: string }) {
             toNavigate={`/posts/${post.slug}`}
             isImagePriority={false}
             title={post.title}
-            description={post.description}
+            description={post.description ?? undefined}
             date={post.pub_date}
             thumbnail={post.thumbnail}
             tags={post.tags ?? []}

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -32,8 +32,8 @@ export async function generateMetadata(
     title: post.title,
     description: post.description,
     keywords: post.keywords
-      ? [...(await parent).keywords, ...post.keywords]
-      : [...(await parent).keywords],
+      ? [...((await parent).keywords ?? []), ...post.keywords]
+      : [...((await parent).keywords ?? [])],
     authors: [
       {
         name: 'Megi',

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -31,7 +31,7 @@ export default async function PostRootPage() {
                 toNavigate={`/posts/${post.slug}`}
                 isImagePriority={index < 6}
                 title={post.title}
-                description={post.description}
+                description={post.description ?? undefined}
                 date={post.pub_date}
                 thumbnail={post.thumbnail}
                 tags={post.tags ?? []}

--- a/app/youtubers/[channelId]/_[videoId]/page.tsx
+++ b/app/youtubers/[channelId]/_[videoId]/page.tsx
@@ -25,13 +25,19 @@ export async function generateMetadata(
   if (!video) return {};
 
   const snippet = video.snippet;
+  const parentMetadata = await parent;
+  const parentKeywords = Array.isArray(parentMetadata.keywords)
+    ? parentMetadata.keywords
+    : parentMetadata.keywords
+      ? [parentMetadata.keywords]
+      : [];
 
   return {
     title: snippet.title,
     description: snippet.channelTitle,
     keywords: snippet.tags
-      ? [...(await parent).keywords, ...snippet.tags, snippet.channelTitle]
-      : [...(await parent).keywords, snippet.channelTitle],
+      ? [...parentKeywords, ...snippet.tags, snippet.channelTitle]
+      : [...parentKeywords, snippet.channelTitle],
     openGraph: {
       title: snippet.title,
       description: snippet.channelTitle,

--- a/app/youtubers/[channelId]/_[videoId]/page.tsx
+++ b/app/youtubers/[channelId]/_[videoId]/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata(
       url: absoluteUrl(video.id),
       images: [
         {
-          url: snippet.thumbnails.maxres.url ?? snippet.thumbnails.high.url,
+          url: snippet.thumbnails.maxres?.url ?? snippet.thumbnails.high.url,
           width: 1200,
           height: 630,
           alt: snippet.title,
@@ -51,7 +51,7 @@ export async function generateMetadata(
       card: 'summary_large_image',
       title: snippet.title,
       description: snippet.channelTitle,
-      images: [snippet.thumbnails.maxres.url ?? snippet.thumbnails.high.url],
+      images: [snippet.thumbnails.maxres?.url ?? snippet.thumbnails.high.url],
     },
     metadataBase: new URL(`${siteConfig.url}${video.id}`),
     alternates: {

--- a/app/youtubers/[channelId]/page.tsx
+++ b/app/youtubers/[channelId]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(
   return {
     title: mutualTitle,
     description: channelTitle,
-    keywords: [...(await parent).keywords, channelTitle],
+    keywords: [...((await parent).keywords ?? []), channelTitle],
     authors: [
       {
         name: 'Megi',
@@ -51,13 +51,13 @@ export async function generateMetadata(
       type: 'article',
       authors: ['Megiii', channelTitle],
       url: absoluteUrl(channelTitle),
-      images: (await parent).openGraph.images,
+      images: (await parent).openGraph?.images,
     },
     twitter: {
       card: 'summary_large_image',
       title: mutualTitle,
       description: channelTitle,
-      images: (await parent).twitter.images,
+      images: (await parent).twitter?.images,
     },
     metadataBase: new URL(`${siteConfig.url}/${channelTitle}`),
     alternates: {
@@ -103,7 +103,7 @@ export default async function YouTuberRootPage({
     팁: videos.filter((video) => video.category === '팁'),
   };
   const nonZeroCategoryKeys = Object.keys(categorizedVideos).filter(
-    (key) => categorizedVideos[key].length > 0,
+    (key) => categorizedVideos[key as keyof typeof categorizedVideos].length > 0,
   );
 
   return (

--- a/app/youtubers/videos/page.tsx
+++ b/app/youtubers/videos/page.tsx
@@ -42,7 +42,7 @@ export default async function YouTubeVideosRootPage({
     팁: combinedAllVideos.filter((video) => video.category === '팁'),
   };
   const nonZeroCategoryKeys = Object.keys(categorizedAllVideos).filter(
-    (key) => categorizedAllVideos[key].length > 0,
+    (key) => categorizedAllVideos[key as keyof typeof categorizedAllVideos].length > 0,
   );
 
   return (

--- a/docs/logs/20260416-strict-true-migration.md
+++ b/docs/logs/20260416-strict-true-migration.md
@@ -1,6 +1,6 @@
-# 2026-04-16 — TypeScript strict: true 전환
+# 2026-04-16 — TypeScript strict 전환 및 build warning fix
 
-> version: 0.1.7
+> version: 0.1.9
 
 ## ♻️ refactor(typescript)
 
@@ -23,3 +23,14 @@
 ## 🔧 chore(deps)
 
 - `@types/react-scroll` devDependency 추가
+
+## 🐛 fix(metadata)
+
+- `app/youtubers/[channelId]/_[videoId]/page.tsx` — `parent.keywords`를 배열로 정규화 후 `snippet.tags` 병합
+- Next.js metadata `keywords`의 `string | string[] | null` union 대응으로 production build type error 해소
+
+## 🐛 fix(proxy)
+
+- `middleware.ts` → `proxy.ts` rename
+- export 함수명 `middleware` → `proxy` 변경
+- Next.js 16.2.3 build warning 제거

--- a/docs/logs/20260416-strict-true-migration.md
+++ b/docs/logs/20260416-strict-true-migration.md
@@ -1,0 +1,25 @@
+# 2026-04-16 — TypeScript strict: true 전환
+
+> version: 0.1.7
+
+## ♻️ refactor(typescript)
+
+- `tsconfig.json` — `strict: false` → `strict: true` 전환
+- 24 파일 / ~50건 type error 수정:
+  - `app/actions/couponRedeem.ts` — `responseData.info` undefined narrowing
+  - `app/actions/handleYTData.ts` — MongoDB `collection<T>()` generic 추가 + null guard
+  - `app/layout.tsx` — `children` binding type + `userAgent` null fallback
+  - `app/page.tsx` — `className` binding type + `description` null → undefined
+  - `app/posts/[slug]/page.tsx`, `app/posts/page.tsx` — keywords null guard, description null 변환
+  - `app/youtubers/**` — thumbnail optional chaining + Korean-key index `as keyof typeof`
+  - `src/components/Blog/Blog.tsx` — optional props (`string | undefined`) + `NavigateComponent` → `React.ElementType`
+  - `src/components/Calendar/Calendar1.tsx` — react-day-picker v9 `required` prop
+  - `src/components/Card/*` — string | undefined fallback (`?? ''`)
+  - `src/components/Video/*` — playerRef typing, timestamps undefined guard, state null 허용
+  - `src/components/Data/ResponseDisplay.tsx` — response prop null 허용
+  - `src/util/db.ts` — `declare global` block 추가
+  - `src/lib/markdown.tsx` — react-dom/server ts-expect-error
+
+## 🔧 chore(deps)
+
+- `@types/react-scroll` devDependency 추가

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krrpinfo",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "private": true,
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "krrpinfo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "license": "MIT",
   "author": {
@@ -89,6 +89,7 @@
     "@next/bundle-analyzer": "^16.2.2",
     "@types/node": "^22.15.0",
     "@types/react": "^19.2.0",
+    "@types/react-scroll": "^1.8.10",
     "commitizen": "^4.3.1",
     "commitlint-config-gitmoji": "^2.3.1",
     "cz-emoji-conventional": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.14
+      '@types/react-scroll':
+        specifier: ^1.8.10
+        version: 1.8.10
       commitizen:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@22.19.17)(typescript@5.9.3)
@@ -1260,6 +1263,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/react-scroll@1.8.10':
+    resolution: {integrity: sha512-RD4Z7grbdNGOKwKnUBKar6zNxqaW3n8m9QSrfvljW+gmkj1GArb8AFBomVr6xMOgHPD3v1uV3BrIf01py57daQ==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -4237,6 +4243,10 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/react-scroll@1.8.10':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react@19.2.14':
     dependencies:

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-// youtubers page feature flag gate
-export function middleware(request: NextRequest) {
+// youtubers 노출 gate
+export function proxy(request: NextRequest) {
   if (process.env.NEXT_PUBLIC_SHOW_YOUTUBERS !== 'true') {
     return new NextResponse(null, { status: 404 });
   }

--- a/src/components/Blog/Blog.tsx
+++ b/src/components/Blog/Blog.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { LinkIcon } from 'lucide-react';
 import Link from 'next/link';
 import ButtonNewTab from '@/components/Button/ButtonNewTab';
@@ -85,20 +86,20 @@ export default function Blog({
   );
 }
 
-interface TextDataWrapperProps {
-  width: string;
-  thumbnail: string;
+type TextDataWrapperProps = {
+  width?: string;
+  thumbnail?: string;
   tags: string[];
-  date: string;
+  date?: string;
   title: string;
-  description: string;
+  description?: string;
   gridNums: number[];
   isPriority: boolean;
-  NavigateComponent?: typeof Link | typeof ButtonNewTab;
+  NavigateComponent?: React.ElementType;
   toNavigate?: string;
   hyperlink?: string;
-  className: string;
-}
+  className?: string;
+};
 
 function TextDataWrapper({
   width,
@@ -116,10 +117,10 @@ function TextDataWrapper({
 }: TextDataWrapperProps) {
   return (
     <div className={cn('rounded-lg focus:outline-hidden', width, className)}>
-      {toNavigate || hyperlink ? (
-        <NavigateComponent href={toNavigate || hyperlink}>
+      {NavigateComponent && (toNavigate || hyperlink) ? (
+        <NavigateComponent href={toNavigate ?? hyperlink ?? ''}>
           <ImageWrapper
-            src={thumbnail}
+            src={thumbnail ?? ''}
             gridNums={gridNums}
             isPriority={isPriority}
             isHyperlink={!!hyperlink}
@@ -128,7 +129,7 @@ function TextDataWrapper({
         </NavigateComponent>
       ) : (
         <ImageWrapper
-          src={thumbnail}
+          src={thumbnail ?? ''}
           gridNums={gridNums}
           isPriority={isPriority}
           className={width}
@@ -140,8 +141,8 @@ function TextDataWrapper({
             {formatDate(date ?? new Date())}
           </p>
         </div>
-        {toNavigate || hyperlink ? (
-          <NavigateComponent href={toNavigate || hyperlink}>
+        {NavigateComponent && (toNavigate || hyperlink) ? (
+          <NavigateComponent href={toNavigate ?? hyperlink ?? ''}>
             <h1 id="title" className="truncate text-2xl font-bold text-primary hover:underline">
               {title}
             </h1>

--- a/src/components/Calendar/Calendar1.tsx
+++ b/src/components/Calendar/Calendar1.tsx
@@ -14,6 +14,7 @@ const Calendar1 = ({ className }: CalendarProps) => {
   return (
     <Calendar
       mode="single"
+      required
       selected={date}
       onSelect={setDate}
       className={cn('rounded-md border', className)}

--- a/src/components/Card/SimpleLinkCard.tsx
+++ b/src/components/Card/SimpleLinkCard.tsx
@@ -32,7 +32,7 @@ export function SimpleLinkCardMD({
         className,
       )}
     >
-      <ButtonNewTab href={hyperlink}>
+      <ButtonNewTab href={hyperlink ?? ''}>
         <div className="relative aspect-video">
           <div className="absolute inset-0 z-10 bg-black opacity-0 transition hover:opacity-20 dark:bg-white" />
           <div className="absolute z-20 rounded-br-md rounded-tl-md bg-white/70 p-2">
@@ -47,7 +47,7 @@ export function SimpleLinkCardMD({
         </div>
       </ButtonNewTab>
       <CardContent className="p-4">
-        <ButtonNewTab href={hyperlink}>
+        <ButtonNewTab href={hyperlink ?? ''}>
           <CardTitle className="truncate text-lg font-bold hover:underline">{title}</CardTitle>
         </ButtonNewTab>
         <Tag
@@ -71,7 +71,7 @@ export function SimpleLinkCardSM({
   className,
 }: SimpleLinkCardProps) {
   return (
-    <ButtonNewTab href={hyperlink} className={cn('w-full', className)}>
+    <ButtonNewTab href={hyperlink ?? ''} className={cn('w-full', className)}>
       {/* mobile only */}
       <Card className="group flex size-full overflow-hidden rounded-lg shadow-sm dark:shadow-zinc-600 dark:hover:bg-zinc-900">
         <div className="relative w-36">

--- a/src/components/Card/YouTubeChannelCard.tsx
+++ b/src/components/Card/YouTubeChannelCard.tsx
@@ -1,35 +1,23 @@
 import Link from 'next/link';
 import ButtonNewTab from '@/components/Button/ButtonNewTab';
 import YouTubeIcon from '@/components/Icons/YouTubeIcon';
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { buttonVariants } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardFooter,
-} from '@/components/ui/card';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import type { YouTubeChannel } from '@/src/types';
 import { cn, truncateNumbers } from '@/src/util/utils';
 
-export default function YouTubeChannelCard({
-  channelData,
-}: {
-  channelData: YouTubeChannel
-}) {
+export default function YouTubeChannelCard({ channelData }: { channelData: YouTubeChannel }) {
   return (
     <Card>
       <CardContent className="flex items-start gap-4 p-4">
         <Avatar className="size-24">
-          <AvatarImage src={channelData.thumbnail.url} alt={channelData.customUrl} />
+          <AvatarImage src={channelData.thumbnail?.url ?? ''} alt={channelData.customUrl ?? ''} />
           <AvatarFallback>YT</AvatarFallback>
         </Avatar>
         <div className="grid gap-2">
           <h3 className="text-xl font-medium leading-none">{channelData.channelTitle}</h3>
-          <p className="text-base leading-none text-gray-500 dark:text-gray-400">{`구독자 ${truncateNumbers(channelData.subscribers)}명`}</p>
+          <p className="text-base leading-none text-gray-500 dark:text-gray-400">{`구독자 ${truncateNumbers(channelData.subscribers ?? 0)}명`}</p>
           <p className="text-base leading-tight">{channelData.channelDescription}</p>
         </div>
       </CardContent>

--- a/src/components/Data/ResponseDisplay.tsx
+++ b/src/components/Data/ResponseDisplay.tsx
@@ -2,10 +2,10 @@
 
 interface ResponseDisplayProps {
   response: {
-    success: boolean
-    message: string
-  }
-  className?: string
+    success: boolean;
+    message: string;
+  } | null;
+  className?: string;
 }
 
 const ResponseDisplay = ({ response, className }: ResponseDisplayProps) => (

--- a/src/components/Video/YouTubeDataInput.tsx
+++ b/src/components/Video/YouTubeDataInput.tsx
@@ -3,7 +3,11 @@
 import { useState } from 'react';
 import { getYouTubeVideoData } from '@/app/actions/fetchYouTube';
 import {
-  appendTimestamps, checkIfChannelExists, checkIfVideoExists, insertOneChannel, insertOneVideo,
+  appendTimestamps,
+  checkIfChannelExists,
+  checkIfVideoExists,
+  insertOneChannel,
+  insertOneVideo,
 } from '@/app/actions/handleYTData';
 import InputComponent from '@/components/Data/InputComponent';
 import ResponseDisplay from '@/components/Data/ResponseDisplay';
@@ -27,13 +31,10 @@ const CategorySelect = ({
   selectedCategory,
   setSelectedCategory,
 }: {
-  selectedCategory: VideoCategory
-  setSelectedCategory: (value: VideoCategory) => void
+  selectedCategory: VideoCategory;
+  setSelectedCategory: (value: string) => void;
 }) => (
-  <Select
-    value={selectedCategory}
-    onValueChange={setSelectedCategory}
-  >
+  <Select value={selectedCategory} onValueChange={setSelectedCategory}>
     <SelectTrigger className="w-full">
       <SelectValue placeholder="Select video category" />
     </SelectTrigger>
@@ -41,7 +42,9 @@ const CategorySelect = ({
       <SelectGroup>
         <SelectLabel>Category</SelectLabel>
         {categories.map((value) => (
-          <SelectItem key={value} value={value}>{capitalizeFirstLetter(value)}</SelectItem>
+          <SelectItem key={value} value={value}>
+            {capitalizeFirstLetter(value)}
+          </SelectItem>
         ))}
       </SelectGroup>
     </SelectContent>
@@ -49,26 +52,29 @@ const CategorySelect = ({
 );
 
 interface ResponseProps {
-  success: boolean
-  message: string
+  success: boolean;
+  message: string;
 }
 
 const YouTubeDataInput = () => {
   const [ytUrl, setYtUrl] = useState('');
-  const [videoData, setVideoData] = useState<YouTubeVideoItem>(null);
-  const [response, setResponse] = useState<ResponseProps>(null);
+  const [videoData, setVideoData] = useState<YouTubeVideoItem | null>(null);
+  const [response, setResponse] = useState<ResponseProps | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<VideoCategory>('현재 시즌');
 
   const handleFetch = () => {
     try {
-      getYouTubeVideoData(ytUrl)
-        .then((data) => setVideoData(data));
+      getYouTubeVideoData(ytUrl).then((data) => setVideoData(data));
     } catch (error) {
-      setResponse({ success: false, message: error });
+      setResponse({
+        success: false,
+        message: error instanceof Error ? error.message : String(error),
+      });
     }
   };
 
   const handleSubmit = async () => {
+    if (!videoData) return;
     const channelId = videoData.snippet.channelId;
     const videoId = videoData.id;
 
@@ -80,7 +86,10 @@ const YouTubeDataInput = () => {
             channelTitle: videoData.snippet.channelTitle,
             allVideos: [{ ...dataToInsert, category: selectedCategory }],
           });
-          setResponse({ success: true, message: `Success, new channel ${videoData.snippet.channelTitle} (${channelId}) created with 1 video` });
+          setResponse({
+            success: true,
+            message: `Success, new channel ${videoData.snippet.channelTitle} (${channelId}) created with 1 video`,
+          });
         });
         return;
       }
@@ -93,7 +102,10 @@ const YouTubeDataInput = () => {
 
         appendTimestamps(videoData).then((dataToInsert) => {
           insertOneVideo(channelId, { ...dataToInsert, category: selectedCategory });
-          setResponse({ success: true, message: `Success, pushed video to ${videoData.snippet.channelTitle} (${channelId})` });
+          setResponse({
+            success: true,
+            message: `Success, pushed video to ${videoData.snippet.channelTitle} (${channelId})`,
+          });
         });
       });
     });
@@ -101,11 +113,7 @@ const YouTubeDataInput = () => {
 
   return (
     <div className="flex w-full flex-col items-center gap-y-4">
-      <InputComponent
-        label="YouTube Video URL Input"
-        value={ytUrl}
-        onChange={setYtUrl}
-      />
+      <InputComponent label="YouTube Video URL Input" value={ytUrl} onChange={setYtUrl} />
       <button
         className={cn(buttonVariants({ variant: 'secondary' }), 'w-full')}
         onClick={handleFetch}
@@ -114,10 +122,21 @@ const YouTubeDataInput = () => {
       </button>
       <button
         className={cn(buttonVariants({ variant: 'secondary' }), 'w-full')}
-        onClick={() => checkIfVideoExists(videoData.snippet.channelId, videoData.id).then((result) => {
-          if (result) setResponse({ success: false, message: `In channel ${videoData.snippet.channelTitle}, Video already exists` });
-          else setResponse({ success: true, message: `In channel ${videoData.snippet.channelTitle}, Video does not exist` });
-        })}
+        onClick={() => {
+          if (!videoData) return;
+          checkIfVideoExists(videoData.snippet.channelId, videoData.id).then((result) => {
+            if (result)
+              setResponse({
+                success: false,
+                message: `In channel ${videoData.snippet.channelTitle}, Video already exists`,
+              });
+            else
+              setResponse({
+                success: true,
+                message: `In channel ${videoData.snippet.channelTitle}, Video does not exist`,
+              });
+          });
+        }}
       >
         Check exist
       </button>
@@ -127,7 +146,7 @@ const YouTubeDataInput = () => {
       </pre>
       <CategorySelect
         selectedCategory={selectedCategory}
-        setSelectedCategory={setSelectedCategory}
+        setSelectedCategory={(value) => setSelectedCategory(value as VideoCategory)}
       />
       <button
         className={cn(
@@ -140,9 +159,7 @@ const YouTubeDataInput = () => {
       >
         Add to DB
       </button>
-      <ResponseDisplay
-        response={response}
-      />
+      <ResponseDisplay response={response} />
     </div>
   );
 };

--- a/src/components/Video/YouTubeModal.tsx
+++ b/src/components/Video/YouTubeModal.tsx
@@ -29,7 +29,7 @@ export function YouTubeModal({ videoData }: YouTubeModalProps) {
         {/* Blog as Trigger only */}
         <div className="pointer-events-none relative focus:outline-hidden">
           <ImageWrapper
-            src={videoData.snippet.thumbnails.maxres.url ?? videoData.snippet.thumbnails.high.url}
+            src={videoData.snippet.thumbnails.maxres?.url ?? videoData.snippet.thumbnails.high.url}
             alt="youtube thumbnail"
             gridNums={[1, 2, 3]}
             isPriority={false}

--- a/src/components/Video/YouTubeModalContent.tsx
+++ b/src/components/Video/YouTubeModalContent.tsx
@@ -11,31 +11,26 @@ interface YouTubeModalContentProps {
   className?: string;
 }
 
-const YouTubeModalContent = ({
-  videoData,
-  className,
-}: YouTubeModalContentProps) => {
+const YouTubeModalContent = ({ videoData, className }: YouTubeModalContentProps) => {
   const { timestamps } = videoData;
 
   const [isWindow, setIsWindow] = useState<boolean>(false);
 
-  const playerRef = useRef(null);
+  const playerRef = useRef<ReactPlayer>(null);
   const [currentTime, setCurrentTime] = useState(0);
   const [playing, setPlaying] = useState(true);
 
   const updateCurrentTime = () => {
-    setCurrentTime(
-      playerRef.current.getCurrentTime()
-        ? playerRef.current.getCurrentTime().toFixed(3)
-        : 0,
-    );
+    if (!playerRef.current) return;
+    const time = playerRef.current.getCurrentTime();
+    setCurrentTime(time ? parseFloat(time.toFixed(3)) : 0);
   };
 
   const isWithinInterval = (indexInput: number) => {
+    if (!timestamps) return false;
     const currentTimeStamp = timestamps[indexInput].seconds;
 
-    if (indexInput === timestamps.length - 1)
-      return currentTimeStamp <= currentTime;
+    if (indexInput === timestamps.length - 1) return currentTimeStamp <= currentTime;
 
     const nextTimeStamp = timestamps[indexInput + 1].seconds;
 
@@ -99,14 +94,12 @@ const YouTubeModalContent = ({
             />
           )}
         </div>
-        <div
-          className="relative flex flex-col overflow-hidden rounded-lg border-2 border-zinc-400 dark:border-zinc-600 laptop:min-w-80"
-        >
+        <div className="relative flex flex-col overflow-hidden rounded-lg border-2 border-zinc-400 dark:border-zinc-600 laptop:min-w-80">
           <div className="p-4 dark:bg-zinc-600">
             <h1 className="text-lg font-medium tablet:text-xl">챕터</h1>
           </div>
           <ScrollArea className="flex h-48 flex-col overflow-hidden laptop:h-[43vh] laptop:min-w-80">
-            {videoData.timestamps.map((timestamp, idx) => (
+            {videoData.timestamps?.map((timestamp, idx) => (
               <button
                 key={timestamp.title}
                 className={cn(
@@ -118,12 +111,8 @@ const YouTubeModalContent = ({
                   setCurrentTime(timestamp.seconds);
                 }}
               >
-                <h1 className="text-base font-medium tablet:text-lg">
-                  {timestamp.title}
-                </h1>
-                <p
-                  className="mt-2 rounded-md bg-blue-300/35 px-1.5 py-0.5 text-left text-sm font-semibold text-blue-600 dark:bg-blue-500/35 dark:text-blue-500 tablet:text-base"
-                >
+                <h1 className="text-base font-medium tablet:text-lg">{timestamp.title}</h1>
+                <p className="mt-2 rounded-md bg-blue-300/35 px-1.5 py-0.5 text-left text-sm font-semibold text-blue-600 dark:bg-blue-500/35 dark:text-blue-500 tablet:text-base">
                   {convertSecondsToTime(timestamp.seconds)}
                 </p>
               </button>

--- a/src/components/Video/YouTubeTimeStampInput.tsx
+++ b/src/components/Video/YouTubeTimeStampInput.tsx
@@ -16,12 +16,12 @@ type EditableTimestampProps = {
 const YouTubeTimestampInput: React.FC<EditableTimestampProps> = ({ videoData }) => {
   const { timestamps } = videoData;
 
-  const [localTimestamps, setLocalTimestamps] = useState<Timestamp[]>([...timestamps]);
+  const [localTimestamps, setLocalTimestamps] = useState<Timestamp[]>([...(timestamps ?? [])]);
   const [tempTimestamps, setTempTimestamps] = useState<Timestamp[]>([]);
   const [editMode, setEditMode] = useState<{ [key: string]: boolean }>({});
 
   useEffect(() => {
-    setLocalTimestamps([...timestamps]);
+    setLocalTimestamps([...(timestamps ?? [])]);
   }, [timestamps]);
 
   const handleToggleEdit = (index: number, isSave: boolean = false) => {
@@ -40,11 +40,15 @@ const YouTubeTimestampInput: React.FC<EditableTimestampProps> = ({ videoData }) 
   };
 
   const handleTitleChange = (index: number, title: string) => {
-    setTempTimestamps((prev) => prev.map((timestamp, idx) => (idx === index ? { ...timestamp, title } : timestamp)));
+    setTempTimestamps((prev) =>
+      prev.map((timestamp, idx) => (idx === index ? { ...timestamp, title } : timestamp)),
+    );
   };
 
   const handleSecondsChange = (index: number, seconds: number) => {
-    setTempTimestamps((prev) => prev.map((timestamp, idx) => (idx === index ? { ...timestamp, seconds } : timestamp)));
+    setTempTimestamps((prev) =>
+      prev.map((timestamp, idx) => (idx === index ? { ...timestamp, seconds } : timestamp)),
+    );
   };
 
   const handleAddTimestamp = () => {
@@ -71,9 +75,7 @@ const YouTubeTimestampInput: React.FC<EditableTimestampProps> = ({ videoData }) 
           {localTimestamps.map((timestamp, idx) => (
             <li key={timestamp.title}>
               {editMode[idx] ? (
-                <div
-                  className="flex w-full flex-col items-start gap-2 px-4 py-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 tablet:p-4"
-                >
+                <div className="flex w-full flex-col items-start gap-2 px-4 py-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 tablet:p-4">
                   <div className="flex w-full items-center gap-2">
                     <h1 className="text-base font-medium tablet:text-lg">Title:</h1>
                     <input
@@ -110,12 +112,8 @@ const YouTubeTimestampInput: React.FC<EditableTimestampProps> = ({ videoData }) 
               ) : (
                 <div className="flex items-center justify-between hover:bg-zinc-100 dark:hover:bg-zinc-800">
                   <div className="flex w-full flex-col items-start gap-2 px-4 py-3 tablet:p-4">
-                    <h1 className="text-base font-medium tablet:text-lg">
-                      {timestamp.title}
-                    </h1>
-                    <p
-                      className="rounded-md bg-blue-300/35 px-1.5 py-0.5 text-left text-sm font-semibold text-blue-600 dark:bg-blue-500/35 dark:text-blue-500 tablet:text-base"
-                    >
+                    <h1 className="text-base font-medium tablet:text-lg">{timestamp.title}</h1>
+                    <p className="rounded-md bg-blue-300/35 px-1.5 py-0.5 text-left text-sm font-semibold text-blue-600 dark:bg-blue-500/35 dark:text-blue-500 tablet:text-base">
                       {convertSecondsToTime(timestamp.seconds)}
                     </p>
                   </div>
@@ -140,16 +138,10 @@ const YouTubeTimestampInput: React.FC<EditableTimestampProps> = ({ videoData }) 
         </ul>
       </ScrollArea>
       <div className="mt-4 flex justify-between gap-6">
-        <button
-          className={cn(buttonVariants(), 'w-full')}
-          onClick={handleAddTimestamp}
-        >
+        <button className={cn(buttonVariants(), 'w-full')} onClick={handleAddTimestamp}>
           + Add Item
         </button>
-        <button
-          className={cn(buttonVariants(), 'w-full')}
-          onClick={handleSave}
-        >
+        <button className={cn(buttonVariants(), 'w-full')} onClick={handleSave}>
           Save
         </button>
       </div>

--- a/src/components/Video/YouTubeVideoTabs.tsx
+++ b/src/components/Video/YouTubeVideoTabs.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import Blog from '@/components/Blog/Blog';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { YouTubeVideoItem } from '@/src/types';
 import { categories } from '@/src/types';
 import { cn, fallBackIndex } from '@/src/util/utils';
@@ -41,9 +36,8 @@ const YouTubeVideoTabs = ({
 
                 // if categoryIndex === 0, then eliminate the query string
                 if (categoryIndex === 0)
-                  window.history.pushState(null, '', `${window.location.pathname}`);
-                else // else, push the query string with the correct index
-                  window.history.pushState(null, '', `?idx=${categoryIndex}`);
+                  window.history.pushState(null, '', `${window.location.pathname}`); // else, push the query string with the correct index
+                else window.history.pushState(null, '', `?idx=${categoryIndex}`);
               }}
               className="h-10 w-full truncate text-base font-medium tablet:h-12 tablet:text-lg laptop:text-xl"
             >
@@ -56,17 +50,16 @@ const YouTubeVideoTabs = ({
     {categories.map((category) => (
       <>
         {categorizedVideos[category].length > 0 && (
-          <TabsContent
-            key={category}
-            value={category}
-          >
+          <TabsContent key={category} value={category}>
             {categorizedVideos[category].length > 0 ? (
               <div className="relative mt-8 grid w-full grid-cols-1 gap-8 tablet:grid-cols-2 laptop:mt-12 laptop:grid-cols-3">
                 {categorizedVideos[category].map((video: YouTubeVideoItem, index: number) => (
                   <Blog
                     key={video.id}
                     hyperlink={`https://www.youtube.com/watch?v=${video.id}`}
-                    thumbnail={video.snippet.thumbnails.maxres.url ?? video.snippet.thumbnails.high.url}
+                    thumbnail={
+                      video.snippet.thumbnails.maxres?.url ?? video.snippet.thumbnails.high.url
+                    }
                     isImagePriority={index < 6}
                     title={video.snippet.title}
                     description={video.snippet.channelTitle}

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -220,6 +220,7 @@ export async function renderMarkdown(content: string): Promise<string> {
       ],
     });
 
+    // @ts-expect-error -- react-dom/server type 선언 누락 우회
     const { renderToString } = await import('react-dom/server');
     const html = renderToString(<MDXContent components={components} />);
     return html;

--- a/src/util/db.ts
+++ b/src/util/db.ts
@@ -1,12 +1,17 @@
 import { MongoClient } from 'mongodb';
 import { env } from '@/env.mjs';
 
+// development 환경 MongoClient 캐싱용 global 선언
+declare global {
+  // eslint-disable-next-line no-var
+  var _mongo: MongoClient | undefined;
+}
+
 const url = env.MONGODB_URL;
 
 const mongoClient = async () => {
   if (process.env.NODE_ENV === 'development') {
-    if (!global._mongo)
-      global._mongo = await new MongoClient(url).connect();
+    if (!global._mongo) global._mongo = await new MongoClient(url).connect();
 
     return global._mongo;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
     "esModuleInterop": true,


### PR DESCRIPTION
# PR: strict/full → develop

## Summary

- `develop` 대비 TypeScript `strict: true` 전환으로 타입 안정성 강화
- youtubers video metadata의 `keywords` 타입 처리 보강으로 Next.js production build 실패 해소
- Next.js 16 deprecation 대응으로 `middleware` warning 제거

## Changes

## ♻️ TypeScript strict 전환

- `tsconfig.json` `strict: true` 활성화
- `app/actions`, `app/posts`, `app/youtubers`, `src/components`, `src/util`, `src/lib` 전반의 null/undefined 타입 처리 정리
- build 단계 TypeScript 오류를 코드 레벨에서 선제 차단

## 🐛 YouTubers metadata build fix

- `app/youtubers/[channelId]/_[videoId]/page.tsx`에서 `parent.keywords`를 배열로 정규화
- `snippet.tags` 유무와 관계없이 metadata `keywords`를 안전하게 병합
- Next.js build type check에서 발생한 spread 오류 해소

## 🐛 Proxy migration

- 루트 `middleware.ts`를 `proxy.ts`로 rename
- export 함수명을 `proxy`로 변경해 Next.js 16 file convention에 맞춤
- 기존 matcher와 feature flag 동작은 유지하면서 build warning만 제거

## 🔧 Version / docs

- `package.json` patch version `0.1.9` 반영
- `docs/logs/20260416-strict-true-migration.md`에 metadata fix와 proxy migration 내역 반영